### PR TITLE
Corrected logic for Azure Firewall IP naming when using `name` parameter on both Default and Management

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -12,7 +12,7 @@ locals {
       tags                  = vnet.firewall.tags
       threat_intel_mode     = vnet.firewall.threat_intel_mode
       default_ip_configuration = {
-        name = try(coalesce(vnet.firewall.management_ip_configuration.name, "default"), "default")
+        name = try(coalesce(vnet.firewall.default_ip_configuration.name, "default"), "default")
       }
       management_ip_configuration = {
         name = try(coalesce(vnet.firewall.management_ip_configuration.name, "defaultMgmt"), "defaultMgmt")


### PR DESCRIPTION
## Describe your changes

As current both `default` and `management` use the `managment_ip_configuration.name`
Corrected `default` to use its own parameter.

## Issue number


## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

