### PR TITLE
Minor corrections to the readme and hub_virtual_networks variable description

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Description: A map of the hub virtual networks to create. The map key is an arbi
   - `zones` - (Optional) A list of availability zones to use for the Azure Firewall. If not specified will be `null`.
   - `default_ip_configuration` - (Optional) An object with the following fields. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the default IP configuration. If not specified will use `default`.
+    - `tags` - (Optional) A map of tags to apply to the public IP configuration.
     - `public_ip_config` - (Optional) An object with the following fields:
       - `name` - (Optional) The name of the public IP configuration. If not specified will use `pip-afw-{vnetname}`.
       - `zones` - (Optional) A list of availability zones to use for the public IP configuration. If not specified will be `null`.
@@ -145,6 +146,7 @@ Description: A map of the hub virtual networks to create. The map key is an arbi
       - `sku_tier` - (Optional) The SKU tier to use for the public IP configuration. Possible values include `Regional`, `Global`. If not specified will be `Regional`.
   - `management_ip_configuration` - (Optional) An object with the following fields. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the management IP configuration. If not specified will use `defaultMgmt`.
+    - `tags` - (Optional) A map of tags to apply to the public IP configuration.
     - `public_ip_config` - (Optional) An object with the following fields:
       - `name` - (Optional) The name of the public IP configuration. If not specified will use `pip-afw-mgmt-<Map Key>`.
       - `zones` - (Optional) A list of availability zones to use for the public IP configuration. If not specified will be `null`.
@@ -226,6 +228,7 @@ map(object({
       zones                            = optional(list(string))
       default_ip_configuration = optional(object({
         name = optional(string)
+        tags = optional(string)
         public_ip_config = optional(object({
           ip_version = optional(string)
           name       = optional(string)
@@ -235,6 +238,7 @@ map(object({
       }))
       management_ip_configuration = optional(object({
         name = optional(string)
+        tags = optional(string)
         public_ip_config = optional(object({
           ip_version = optional(string)
           name       = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -167,17 +167,17 @@ A map of the hub virtual networks to create. The map key is an arbitrary value t
   - `zones` - (Optional) A list of availability zones to use for the Azure Firewall. If not specified will be `null`.
   - `default_ip_configuration` - (Optional) An object with the following fields. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the default IP configuration. If not specified will use `default`.
+    - `tags` - (Optional) A map of tags to apply to the public IP configuration.
     - `public_ip_config` - (Optional) An object with the following fields:
       - `name` - (Optional) The name of the public IP configuration. If not specified will use `pip-afw-{vnetname}`.
-      - `tags` - (Optional) A map of tags to apply to the public IP configuration.
       - `zones` - (Optional) A list of availability zones to use for the public IP configuration. If not specified will be `null`.
       - `ip_version` - (Optional) The IP version to use for the public IP configuration. Possible values include `IPv4`, `IPv6`. If not specified will be `IPv4`.
       - `sku_tier` - (Optional) The SKU tier to use for the public IP configuration. Possible values include `Regional`, `Global`. If not specified will be `Regional`.
   - `management_ip_configuration` - (Optional) An object with the following fields. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the management IP configuration. If not specified will use `defaultMgmt`.
+    - `tags` - (Optional) A map of tags to apply to the public IP configuration.
     - `public_ip_config` - (Optional) An object with the following fields:
       - `name` - (Optional) The name of the public IP configuration. If not specified will use `pip-afw-mgmt-<Map Key>`.
-      - `tags` - (Optional) A map of tags to apply to the public IP configuration.
       - `zones` - (Optional) A list of availability zones to use for the public IP configuration. If not specified will be `null`.
       - `ip_version` - (Optional) The IP version to use for the public IP configuration. Possible values include `IPv4`, `IPv6`. If not specified will be `IPv4`.
       - `sku_tier` - (Optional) The SKU tier to use for the public IP configuration. Possible values include `Regional`, `Global`. If not specified will be `Regional`.


### PR DESCRIPTION
The tag property for both default_ip_configuration and management_ip_configuration are set a level up from where the description indicated. 

## Describe your changes
This pull request includes updates to the `README.md` and `variables.tf` files to add optional `tags` fields to the configurations for public IPs in both default and management IP configurations.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R141-R149): Added optional `tags` fields to the descriptions of both `default_ip_configuration` and `management_ip_configuration` to allow users to apply tags to public IP configurations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R141-R149) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R231) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R241)

### Configuration Updates:

* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR170-L180): Added optional `tags` fields to both `default_ip_configuration` and `management_ip_configuration` to support tagging of public IP configurations.

## Issue number

#000

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

